### PR TITLE
Change browser key to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cognite/three-combo-controls",
   "version": "1.2.5",
   "description": "Orbit & first person camera controller for THREE.JS",
-  "browser": "dist/main.js",
+  "main": "dist/main.js",
   "contributors": [
     "Fredrik Anfinsen <fredrik.anfinsen@cognite.com>",
     "Haowei Guo <haowei.guo@cognite.com>"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.5",
   "description": "Orbit & first person camera controller for THREE.JS",
   "main": "dist/main.js",
+  "browser": "dist/main.js",
   "contributors": [
     "Fredrik Anfinsen <fredrik.anfinsen@cognite.com>",
     "Haowei Guo <haowei.guo@cognite.com>"


### PR DESCRIPTION
Was seeing failed tests in watchtower due to not being able to find
this package. The "browser" key was having no effect in the package,
but it seems to be meant to serve the same purpose as the "main" key
(primary entry point to the program). Changed to main key and tests
are passing.