### PR TITLE
Fix wobbly camera due to too strong damping

### DIFF
--- a/src/ComboControls.ts
+++ b/src/ComboControls.ts
@@ -148,7 +148,7 @@ export default class ComboControls extends EventDispatcher {
     let changed = false;
 
     const wantDamping = enableDamping && !this.temporarilyDisableDamping;
-    const deltaFactor = wantDamping ? Math.min(dampingFactor * this.targetFPSOverActualFPS) : 1;
+    const deltaFactor = wantDamping ? Math.min(dampingFactor * this.targetFPSOverActualFPS, 1) : 1;
     this.temporarilyDisableDamping = false;
 
     if (


### PR DESCRIPTION
... by sending more than one value to Math.min(). In this case we cap the deltaFactor at 1.

Fixes #cognitedata/3d-viewer/845