### PR TITLE
Use dynamicTarget only for keyboard events

### DIFF
--- a/src/ComboControls.ts
+++ b/src/ComboControls.ts
@@ -261,7 +261,7 @@ export default class ComboControls extends EventDispatcher {
       this.camera.isPerspectiveCamera ?
       this.getDollyDeltaDistance(dollyIn, Math.abs(delta)) :
       Math.sign(delta) * this.orthographicCameraDollyFactor;
-    this.dolly(x, y, deltaDistance);
+    this.dolly(x, y, deltaDistance, false);
   }
 
   private onTouchStart = (event: TouchEvent) => {
@@ -433,7 +433,7 @@ export default class ComboControls extends EventDispatcher {
   private handleKeyboard = () => {
     if (!this.enabled || !this.enableKeyboardNavigation) { return; }
 
-    const { keyboard, keyboardDollySpeed, keyboardPanSpeed, keyboardSpeedFactor } = this;
+    const { keyboard, keyboardDollySpeed, keyboardPanSpeed, keyboardSpeedFactor, dynamicTarget } = this;
 
     // rotate
     const azimuthAngle =
@@ -458,7 +458,7 @@ export default class ComboControls extends EventDispatcher {
     const speedFactor = (keyboard.isPressed('shift') ? keyboardSpeedFactor : 1);
     const moveForward = keyboard.isPressed('w') ? true : keyboard.isPressed('s') ? false : undefined;
     if (moveForward !== undefined) {
-      this.dolly(0, 0, this.getDollyDeltaDistance(moveForward, keyboardDollySpeed * speedFactor));
+      this.dolly(0, 0, this.getDollyDeltaDistance(moveForward, keyboardDollySpeed * speedFactor), dynamicTarget);
       this.firstPersonMode = true;
     }
 
@@ -532,9 +532,8 @@ export default class ComboControls extends EventDispatcher {
     camera.updateProjectionMatrix();
   }
 
-  private dollyPerspectiveCamera = (x: number, y: number, deltaDistance: number) => {
+  private dollyPerspectiveCamera = (x: number, y: number, deltaDistance: number, dynamicTarget: boolean) => {
     const {
-      dynamicTarget,
       minDistance,
       raycaster,
       reusableVector3,
@@ -585,14 +584,14 @@ export default class ComboControls extends EventDispatcher {
     targetEnd.add(targetOffset);
   }
 
-  private dolly = (x: number, y: number, deltaDistance: number) => {
+  private dolly = (x: number, y: number, deltaDistance: number, dynamicTarget: boolean) => {
     const { camera } = this;
     // @ts-ignore
     if (camera.isOrthographicCamera) {
       this.dollyOrthographicCamera(x, y, deltaDistance);
     // @ts-ignore
     } else if (camera.isPerspectiveCamera) {
-      this.dollyPerspectiveCamera(x, y, deltaDistance);
+      this.dollyPerspectiveCamera(x, y, deltaDistance, dynamicTarget);
     }
   }
 


### PR DESCRIPTION
This fixes cases where scrolling would suddenly start moving the
camera target. Instead, the camera stops at minDistance when scrolling.