### PR TITLE
Revert to behavior of v1.2.4 except damping fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/three-combo-controls",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Orbit & first person camera controller for THREE.JS",
   "main": "dist/main.js",
   "browser": "dist/main.js",


### PR DESCRIPTION
This change reverts the changes that
made it impossible to move the camera target by scrolling.
This is needed to fix cognitedata/3d-viewer#944
The fix for wobbly cameras in #27 is kept intact.

Also bump to version 1.2.8