### PR TITLE
Increase dolly speed by adding back minDistance fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/three-combo-controls",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Orbit & first person camera controller for THREE.JS",
   "main": "dist/main.js",
   "browser": "dist/main.js",

--- a/src/ComboControls.ts
+++ b/src/ComboControls.ts
@@ -52,6 +52,7 @@ export default class ComboControls extends EventDispatcher {
   public maxPolarAngle: number = Math.PI; // radians
   public minAzimuthAngle: number = -Infinity; // radians
   public maxAzimuthAngle: number = Infinity; // radians
+  public panDollyMinDistanceFactor: number = 10.0;
   public firstPersonRotationFactor: number = 0.4;
   public pointerRotationSpeedAzimuth: number = defaultPointerRotationSpeed; // radians per pixel
   public pointerRotationSpeedPolar: number = defaultPointerRotationSpeed; // radians per pixel
@@ -496,6 +497,7 @@ export default class ComboControls extends EventDispatcher {
 
     offsetVector.copy(camera.position).sub(target);
     let targetDistance = offsetVector.length();
+    targetDistance = Math.max(targetDistance, this.panDollyMinDistanceFactor * this.minDistance);
 
     // half of the fov is center to top of screen
     // @ts-ignore
@@ -581,7 +583,9 @@ export default class ComboControls extends EventDispatcher {
     const { sphericalEnd, dollyFactor } = this;
     const zoomFactor = dollyFactor ** steps;
     const factor = dollyIn ? zoomFactor : 1 / zoomFactor;
-    return sphericalEnd.radius * (factor - 1);
+    const distance = Math.max(sphericalEnd.radius,
+      this.panDollyMinDistanceFactor * this.minDistance);
+    return distance * (factor - 1);
   };
 
   private panLeft = (distance: number) => {


### PR DESCRIPTION
This adds back the changes from #25, which were reverted in #30