### PR TITLE
Respect the enabled property in the update function

### DIFF
--- a/src/ComboControls.ts
+++ b/src/ComboControls.ts
@@ -124,8 +124,13 @@ export default class ComboControls extends EventDispatcher {
       enableDamping,
       dampingFactor,
       EPSILON,
-      targetFPS
+      targetFPS,
+      enabled
     } = this;
+
+    if (!enabled) {
+      return false;
+    }
 
     // the target framerate
     const actualFPS = Math.min(1 / deltaTime, targetFPS);


### PR DESCRIPTION
If the camera controls are not enabled, we should no longer update
the camera.