### PR TITLE
Don't record keys when meta being pressed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/three-combo-controls",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "Orbit & first person camera controller for THREE.JS",
   "main": "dist/main.js",
   "browser": "dist/main.js",

--- a/src/Keyboard.ts
+++ b/src/Keyboard.ts
@@ -24,6 +24,10 @@ export default class Keyboard {
     });
 
     window.addEventListener('keydown', event => {
+      if (event.metaKey) {
+        return;
+      }
+
       if (event.keyCode in keyMap) {
         if (this.keys[keyMap[event.keyCode]] === 0) {
           this.keys[keyMap[event.keyCode]] = 2;

--- a/src/Keyboard.ts
+++ b/src/Keyboard.ts
@@ -24,7 +24,7 @@ export default class Keyboard {
     });
 
     window.addEventListener('keydown', event => {
-      if (event.metaKey) {
+      if (event.metaKey || event.altKey || event.ctrlKey) {
         return;
       }
 


### PR DESCRIPTION
If a user presses `cmd+a` or `ctrl+a` to e.g. select all text in a text box (or for any other reason), the camera controls goes into infinite move.

This PR skips all key presses if meta is pressed, which works NOW, but we might want to be able to use these keys later on. But as a hot fix, it is ok.

Relevant bug reports:
https://github.com/cognitedata/operations-support/issues/1009

https://github.com/cognitedata/3d-viewer/issues/657