### PR TITLE
chore: bump version to 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/three-combo-controls",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Orbit & first person camera controller for THREE.JS",
   "main": "dist/main.js",
   "browser": "dist/main.js",


### PR DESCRIPTION
Published to npm https://www.npmjs.com/package/@cognite/three-combo-controls/v/1.4.2