### PR TITLE
[REV-27] fix(mousemove): calculate X,Y offset correctly

### DIFF
--- a/src/ComboControls.ts
+++ b/src/ComboControls.ts
@@ -354,10 +354,9 @@ export default class ComboControls extends EventDispatcher {
   };
 
   private startMouseRotation = (initialEvent: MouseEvent) => {
-    let previousOffset = new Vector2(initialEvent.offsetX, initialEvent.offsetY);
-
+    let previousOffset = getHTMLOffset(this.domElement, initialEvent.clientX, initialEvent.clientY);
     const onMouseMove = (event: MouseEvent) => {
-      const newOffset = new Vector2(event.offsetX, event.offsetY);
+      const newOffset = getHTMLOffset(this.domElement, event.clientX, event.clientY);
       const deltaOffset = previousOffset.clone().sub(newOffset);
       this._accumulatedMouseMove.add(deltaOffset);
       previousOffset = newOffset;
@@ -373,10 +372,10 @@ export default class ComboControls extends EventDispatcher {
   };
 
   private startMousePan = (initialEvent: MouseEvent) => {
-    let previousOffset = new Vector2(initialEvent.offsetX, initialEvent.offsetY);
+    let previousOffset = getHTMLOffset(this.domElement, initialEvent.clientX, initialEvent.clientY);
 
     const onMouseMove = (event: MouseEvent) => {
-      const newOffset = new Vector2(event.offsetX, event.offsetY);
+      const newOffset = getHTMLOffset(this.domElement, event.clientX, event.clientY);
       const xDifference = newOffset.x - previousOffset.x;
       const yDifference = newOffset.y - previousOffset.y;
       previousOffset = newOffset;


### PR DESCRIPTION
Use window relative coords, not event.target relative.

See [Jira issue](https://cognitedata.atlassian.net/browse/REV-27) to check the video.